### PR TITLE
Install nlohmann-json3-dev for zed_components (ZED SDK 5.3)

### DIFF
--- a/docker/Dockerfile.l4t-humble
+++ b/docker/Dockerfile.l4t-humble
@@ -60,7 +60,7 @@ RUN echo "# R${L4T_MAJOR} (release), REVISION: ${L4T_MINOR}" > /etc/nv_tegra_rel
   apt-get update -y || true && \
   apt-get install -y --no-install-recommends zstd wget less cmake curl gnupg2 \
   build-essential python3 python3-pip python3-dev python3-setuptools libusb-1.0-0-dev \ 
-  libgeographic-dev libdraco-dev zlib1g-dev -y && \
+  libgeographic-dev libdraco-dev zlib1g-dev nlohmann-json3-dev -y && \
   export PIP_INDEX_URL="${PYPI_URL}" && \
   pip install protobuf && \
   wget -q --no-check-certificate -O ZED_SDK_Linux_JP.run \


### PR DESCRIPTION
## Summary
Follow-up to #6. ZED SDK 5.3 added a required `find_package(nlohmann_json REQUIRED)` to `zed_components/CMakeLists.txt`. The L4T Dockerfile installs dependencies manually (no `rosdep`), so the build of `zed_components` fails with:

```
CMake Error at CMakeLists.txt:84 (find_package):
  Could not find a package configuration file provided by "nlohmann_json"
```

This adds the `nlohmann-json3-dev` apt package to `docker/Dockerfile.l4t-humble`.

## Notes
- The desktop Dockerfile is unaffected since it runs `rosdep install`, which resolves the `nlohmann-json-dev` key from `package.xml`.

## Test plan
- [ ] Build the zed-wrapper L4T image and confirm `zed_components` compiles.

Made with [Cursor](https://cursor.com)